### PR TITLE
Update zoom_rpm_key variables for Nov 2022 signing key

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,8 +8,8 @@ installw: "{{ _installw[zoom_state] }}"
 
 zoom_deb_url: "https://zoom.us/client/latest/zoom_amd64.deb"
 
-zoom_rpm_key_url: "https://zoom.us/linux/download/pubkey"
-zoom_rpm_key_fingerprint: "3960 60CA DD8A 7522 0BFC B369 B903 BF18 61A7 C71D"
+zoom_rpm_key_url: "https://zoom.us/linux/download/pubkey?version=5-12-6"
+zoom_rpm_key_fingerprint: "59C8 6188 E22A BB19 BD55 4047 7B04 A1B8 DD79 B481"
 
 _zoom_rpm_url:
   default: ""


### PR DESCRIPTION
The original signing key pair has been retired with all releases after Nov 1, 2022 using a new GPG signing key pair. This took place for versions starting at 5.12.6.

https://support.zoom.us/hc/en-us/articles/9836712961165-Downloading-the-public-key-for-Linux
https://zoom.us/download?os=linux